### PR TITLE
Don't assume location of bash

### DIFF
--- a/argsparse-completion.sh
+++ b/argsparse-completion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- tab-width: 4; encoding: utf-8; -*-
 #
 #########

--- a/argsparse.sh
+++ b/argsparse.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- tab-width: 4; encoding: utf-8; -*-
 #
 #########

--- a/tutorial/0-completion
+++ b/tutorial/0-completion
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tutorial_directory=${BASH_SOURCE[0]%/*}
 

--- a/tutorial/1-basics
+++ b/tutorial/1-basics
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PATH="..:$PATH"
 

--- a/tutorial/2-values
+++ b/tutorial/2-values
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 
 PATH="..:$PATH"

--- a/tutorial/3-cumulative-options
+++ b/tutorial/3-cumulative-options
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PATH="..:$PATH"
 

--- a/tutorial/4-types
+++ b/tutorial/4-types
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PATH="..:$PATH"
 

--- a/tutorial/5-custom-types
+++ b/tutorial/5-custom-types
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PATH="..:$PATH"
 

--- a/tutorial/6-properties
+++ b/tutorial/6-properties
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PATH="..:$PATH"
 

--- a/tutorial/7-value-checking
+++ b/tutorial/7-value-checking
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PATH="..:$PATH"
 

--- a/tutorial/8-setting-hook
+++ b/tutorial/8-setting-hook
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PATH="..:$PATH"
 

--- a/tutorial/9-misc
+++ b/tutorial/9-misc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PATH="..:$PATH"
 

--- a/unittest
+++ b/unittest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # -*- tab-width: 4; encoding: utf-8 -*-
 #
 #


### PR DESCRIPTION
Not all environments (NixOS, for example) put bash in /bin. It's more portable to use
`/usr/bin/env bash`, which looks up the location of bash dynamically. In
practice the location of the env command is fairly standardized.