### PR TITLE
Use standard printf formatting character

### DIFF
--- a/unittest
+++ b/unittest
@@ -444,7 +444,7 @@ fi
 
 if [[ $errors -ne 0 ]]
 then
-	printf "* %* d error(s) encountered. (See above)\n" "$errors"
+	printf "* %d * error(s) encountered. (See above)\n" "$errors"
 	exit_code=1
 else
 	printf "All tests passed.\n"


### PR DESCRIPTION
I was seeing this error when running the unittest script:
```
./unittest: line 447: printf: ` ': invalid format character
```
I'm not sure what the desired reporting line should be here, so I made a guess that it was the number, flanked by `*` characters.