### PR TITLE
Add homepage to control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends: debhelper (>= 7.0.50), doxygen
 Package: bash-argsparse
 Architecture: all
 Depends: bash (>= 4), util-linux
+Homepage: https://github.com/Anvil/bash-argsparse
 Description: An high level argument parsing library for bash 
  An high level argument parsing library for bash.
  .


### PR DESCRIPTION
I've added a link to the project's homepage in the pull request/commit because I was looking at the Debian package:

* https://salsa.debian.org/debian/bash-argsparse
* https://packages.debian.org/sid/bash-argsparse

and wanted to see more info/docu about the software. Since the project's homepage was missing in the package itself I had to google around and was not sure if the web page I found was really the upstream of the package.

Adding the homepage directly to the package/control file would simplify the procedure of finding more info on the package/software.