### PR TITLE
Allow requiring that options precede parameters

### DIFF
--- a/argsparse.sh
+++ b/argsparse.sh
@@ -1341,6 +1341,33 @@ argsparse_allow_no_argument() {
 }
 
 
+# Default behaviour is to continue parsing options after a non-option parameter
+# is encountered.
+__argsparse_scanning_mode=""
+
+
+## @fn argsparse_options_first()
+## @brief Stop parsing options once a non-option parameter is encountered.
+## @details Change argsparse behaviour to require that options
+## precede non-options.  Default is to ignore order.
+## @param string if (case-insensitive) "yes", "true" or "1", the value
+## is considered as affirmative. Anything else is a negative value.
+## @retval 0 unless there's more than one parameter (or none).
+## @ingroup ArgsparseParameter
+argsparse_options_first() {
+	[[ $# -eq 1 ]] || return 1
+	local param=$1
+	case "${param,,}" in
+		yes|true|1)
+			__argsparse_scanning_mode="+"
+			;;
+		*)
+			__argsparse_scanning_mode=""
+			;;
+	esac
+}
+
+
 ## @brief Internal use only.
 ## @details The default minimum parameters requirement for command line.
 ## @ingroup ArgsparseParameter
@@ -1760,7 +1787,7 @@ __argsparse_parse_options_no_usage() {
 
 	# 4. Invoke getopt and replace arguments.
 	if ! getopt_temp=$(getopt -s bash -n "$argsparse_pgm" \
-		--longoptions="$longs" "$shorts" "$@")
+		--longoptions="$longs" "$__argsparse_scanning_mode$shorts" "$@")
 	then
 		# Syntax error on the command implies returning with error.
 		return 1

--- a/unittest
+++ b/unittest
@@ -172,6 +172,16 @@ parse_option_wrapper() {
 )
 
 (
+	argsparse_use_option option1 ""
+
+	argsparse_options_first yes
+	parse_option_wrapper "stop at nonoption" --option1 nonoption --invalid
+
+	argsparse_options_first no
+	TEST=failure parse_option_wrapper "don't stop at nonoption" --option1 nonoption --invalid
+)
+
+(
 	argsparse_use_option =shortcut ""
 	parse_option_wrapper "= in optstring" -s
 )


### PR DESCRIPTION
GNU getopt, at least, provides multiple "scanning modes" that affect how it parses interleaved options and parameters.  This PR exposes the choice to an application using the argsparse library.

This can be useful in implementing commands with subcommands, where the order of arguments matters.  For example, status quo could not distinguish `git -p log` from `git log -p`, even with two invocations of argsparse.